### PR TITLE
[BUGFIX] Allow conversion of non-array values to collections

### DIFF
--- a/src/Helper/ArrayHelper.php
+++ b/src/Helper/ArrayHelper.php
@@ -31,6 +31,7 @@ use function array_shift;
 use function array_slice;
 use function gettype;
 use function implode;
+use function is_array;
 use function is_string;
 use function str_getcsv;
 use function trim;
@@ -86,12 +87,17 @@ final class ArrayHelper
 
             // Handle non-array values
             if (!is_array($reference)) {
-                throw new Exception\ArrayPathHasUnexpectedType(implode('.', $currentPathSegments), 'array', gettype($reference));
+                if ([] !== $remainingSegments) {
+                    throw new Exception\ArrayPathHasUnexpectedType(implode('.', $currentPathSegments), 'array', gettype($reference));
+                }
+
+                // This is actually superfluous, it's just here to make PHPStan happy.
+                break;
             }
         }
 
         // Convert array to list
-        if (!array_is_list($reference)) {
+        if (!is_array($reference) || !array_is_list($reference)) {
             $reference = [$reference];
         }
 

--- a/tests/src/Helper/ArrayHelperTest.php
+++ b/tests/src/Helper/ArrayHelperTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\ValinorXml\Tests\Helper;
 
 use EliasHaeussler\ValinorXml as Src;
+use Generator;
 use PHPUnit\Framework;
 
 /**
@@ -62,7 +63,7 @@ final class ArrayHelperTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function convertToCollectionConvertsRespectsListPlaceholders(): void
+    public function convertToCollectionRespectsListPlaceholders(): void
     {
         $array = [
             'foo' => [
@@ -115,8 +116,12 @@ final class ArrayHelperTest extends Framework\TestCase
         Src\Helper\ArrayHelper::convertToCollection($array, 'foo.baz');
     }
 
+    /**
+     * @param array<string, mixed> $expected
+     */
     #[Framework\Attributes\Test]
-    public function convertToCollectionConvertsGivenPathToCollection(): void
+    #[Framework\Attributes\DataProvider('convertToCollectionConvertsGivenPathToCollectionDataProvider')]
+    public function convertToCollectionConvertsGivenPathToCollection(string $path, array $expected): void
     {
         $array = [
             'foo' => [
@@ -126,16 +131,37 @@ final class ArrayHelperTest extends Framework\TestCase
             ],
         ];
 
-        $expected = [
-            'foo' => [
-                'baz' => [
-                    [
-                        'hello' => 'world',
+        self::assertSame($expected, Src\Helper\ArrayHelper::convertToCollection($array, $path));
+    }
+
+    /**
+     * @return Generator<string, array{string, array<string, mixed>}>
+     */
+    public static function convertToCollectionConvertsGivenPathToCollectionDataProvider(): Generator
+    {
+        yield 'array to list' => [
+            'foo.baz',
+            [
+                'foo' => [
+                    'baz' => [
+                        [
+                            'hello' => 'world',
+                        ],
                     ],
                 ],
             ],
         ];
-
-        self::assertSame($expected, Src\Helper\ArrayHelper::convertToCollection($array, 'foo.baz'));
+        yield 'non-array to list' => [
+            'foo.baz.hello',
+            [
+                'foo' => [
+                    'baz' => [
+                        'hello' => [
+                            'world',
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
This PR fixes an edge-case where non-array values could not be converted to collections.

Given the following array:

```php
$array = [
    'foo' => [
        'baz' => [
            'hello' => 'world',
        ],
    ],
];
```

Prior to this PR, running `Helper\ArrayHelper::convertToCollection($array, 'foo.baz.hello')` lead to an exception due to an unsafe `is_array` check on the last path segment (`hello`). This check has now been loosened, and it allows non-array values of the last path segment as well.

This is the result:

```php
$result = [
    'foo' => [
        'baz' => [
            'hello' => [
                'world',
            ],
        ],
    ],
];
```